### PR TITLE
Feature/budget-checking-show-only-failed-tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,42 +1,43 @@
- /**
-  * grunt-sitespeed.io (http://www.sitespeed.io)
-  * Copyright (c) 2015, Peter Hedenskog, Tobias Lidskog
-  * and other contributors
-  * Released under the Apache 2.0 License
-  */
- 'use strict';
+/**
+ * grunt-sitespeed.io (http://www.sitespeed.io)
+ * Copyright (c) 2015, Peter Hedenskog, Tobias Lidskog
+ * and other contributors
+ * Released under the Apache 2.0 License
+ */
+'use strict';
 
- module.exports = function(grunt) {
+module.exports = function(grunt) {
 
-     // Project configuration.
-     grunt.initConfig({
-         // Before generating any new files, remove any previously-created files.
-         clean: {
-             tests: ['tmp']
-         },
-         nodeunit: {
-             all: ['test/test_*.js']
-         },
+  // Project configuration.
+  grunt.initConfig({
+    // Before generating any new files, remove any previously-created files.
+    clean: {
+      tests: ['tmp']
+    },
+    nodeunit: {
+      all: ['test/test_*.js']
+    },
 
-         // Configuration to be run (and then tested).
-         sitespeedio: {
-             default_options: {
-                 options: {}
-             }
-         }
+    // Configuration to be run (and then tested).
+    sitespeedio: {
+      default_options: {
+        options: {
+        }
+      }
+    }
 
-     });
+  });
 
-     // Actually load this plugin's task(s).
-     grunt.loadTasks('tasks');
+  // Actually load this plugin's task(s).
+  grunt.loadTasks('tasks');
 
-     // These plugins provide necessary tasks.
-     grunt.loadNpmTasks('grunt-contrib-clean');
-     grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  // These plugins provide necessary tasks.
+  grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
-     // Whenever the "test" task is run, first clean the "tmp" dir, then run this
-     // plugin's task(s), then test the result.
-     grunt.registerTask('test', ['clean', 'sitespeedio']);
-     grunt.registerTask('test_acceptance', ['nodeunit:all']);
-     grunt.registerTask('default', 'test');
- };
+  // Whenever the "test" task is run, first clean the "tmp" dir, then run this
+  // plugin's task(s), then test the result.
+  grunt.registerTask('test', ['clean', 'sitespeedio']);
+  grunt.registerTask('test_acceptance', ['nodeunit:all']);
+  grunt.registerTask('default', 'test');
+};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,39 +1,42 @@
  /**
- * grunt-sitespeed.io (http://www.sitespeed.io)
- * Copyright (c) 2015, Peter Hedenskog, Tobias Lidskog
- * and other contributors
- * Released under the Apache 2.0 License
- */
+  * grunt-sitespeed.io (http://www.sitespeed.io)
+  * Copyright (c) 2015, Peter Hedenskog, Tobias Lidskog
+  * and other contributors
+  * Released under the Apache 2.0 License
+  */
+ 'use strict';
 
-'use strict';
+ module.exports = function(grunt) {
 
-module.exports = function(grunt) {
+     // Project configuration.
+     grunt.initConfig({
+         // Before generating any new files, remove any previously-created files.
+         clean: {
+             tests: ['tmp']
+         },
+         nodeunit: {
+             all: ['test/test_*.js']
+         },
 
-  // Project configuration.
-  grunt.initConfig( {
-    // Before generating any new files, remove any previously-created files.
-    clean: {
-      tests: ['tmp']
-    },
+         // Configuration to be run (and then tested).
+         sitespeedio: {
+             default_options: {
+                 options: {}
+             }
+         }
 
-    // Configuration to be run (and then tested).
-    sitespeedio: {
-      default_options: {
-        options: {
-        }
-      }
-    }
+     });
 
-  });
+     // Actually load this plugin's task(s).
+     grunt.loadTasks('tasks');
 
-  // Actually load this plugin's task(s).
-  grunt.loadTasks('tasks');
+     // These plugins provide necessary tasks.
+     grunt.loadNpmTasks('grunt-contrib-clean');
+     grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
-  // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-clean');
-
-  // Whenever the "test" task is run, first clean the "tmp" dir, then run this
-  // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'sitespeedio']);
-  grunt.registerTask('default', 'test');
-};
+     // Whenever the "test" task is run, first clean the "tmp" dir, then run this
+     // plugin's task(s), then test the result.
+     grunt.registerTask('test', ['clean', 'sitespeedio']);
+     grunt.registerTask('test_acceptance', ['nodeunit:all']);
+     grunt.registerTask('default', 'test');
+ };

--- a/package.json
+++ b/package.json
@@ -34,10 +34,12 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-contrib-clean": "^0.6.0"
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-nodeunit": "^0.4.1"
   },
   "dependencies": {
     "sitespeed.io": "3.1.12",
+    "hooker": "^0.2.3",
     "temporary": "0.0.8"
   },
   "peerDependencies": {

--- a/tasks/lib/performance_analyzer.js
+++ b/tasks/lib/performance_analyzer.js
@@ -1,0 +1,42 @@
+'use strict'
+
+exports.checkBudget = function(data, grunt) {
+    // lets get the budget!
+    grunt.log.ok('------------------------------------------------- Check budget');
+    var failing = false;
+    var includePassed = grunt.config.get('includePassed');
+    var showFailedOnly = grunt.config.get('showFailedOnly');
+
+    var noPassedTests = 0;
+    var noFailingTests = 0;
+    var noSkippedTests = 0;
+
+    grunt.log.ok((includePassed ? 'Will include passing tests.' : 'Will not include passing tests.') +
+        ' Change this by set grunt config to includePassed to true/false');
+
+    data.budget.forEach(function(result) {
+        if (result.skipped) {
+            noSkippedTests++;
+            if(!showFailedOnly)
+                grunt.log.ok('Skipping ' + result.title + ' ' + result.url + ' ' + ' value [' + result.value +
+                    ']');
+        } else if (result.isOk) {
+            noPassedTests++;
+            if (includePassed && !showFailedOnly) {
+                grunt.log.ok('The budget for ' + result.title + ' ' + result.url + ' passed [' + result.value +
+                    ']');
+            }
+        } else {
+            noFailingTests++;
+            failing = true;
+            grunt.log.error('[FAILED] The budget for ' + result.title + ' ' + result.url + ' failed. ' + result.description);
+        }
+    });
+
+    grunt.log.ok('We got ' + noPassedTests + ' passing tests, ' + noFailingTests + ' failing' + ((
+        noSkippedTests > 0) ? ' ' + noSkippedTests + ' skipped tests' : '.'));
+
+    grunt.log.ok('------------------------------------------------- Finished checking budget');
+
+    return failing;
+}

--- a/tasks/lib/performance_analyzer.js
+++ b/tasks/lib/performance_analyzer.js
@@ -1,42 +1,42 @@
 'use strict'
 
 exports.checkBudget = function(data, grunt) {
-    // lets get the budget!
-    grunt.log.ok('------------------------------------------------- Check budget');
-    var failing = false;
-    var includePassed = grunt.config.get('includePassed');
-    var showFailedOnly = grunt.config.get('showFailedOnly');
+  // lets get the budget!
+  grunt.log.ok('------------------------------------------------- Check budget');
+  var failing = false;
+  var includePassed = grunt.config.get('includePassed');
+  var showFailedOnly = grunt.config.get('showFailedOnly');
 
-    var noPassedTests = 0;
-    var noFailingTests = 0;
-    var noSkippedTests = 0;
+  var noPassedTests = 0;
+  var noFailingTests = 0;
+  var noSkippedTests = 0;
 
-    grunt.log.ok((includePassed ? 'Will include passing tests.' : 'Will not include passing tests.') +
-        ' Change this by set grunt config to includePassed to true/false');
+  grunt.log.ok((includePassed ? 'Will include passing tests.' : 'Will not include passing tests.') +
+    ' Change this by set grunt config to includePassed to true/false');
 
-    data.budget.forEach(function(result) {
-        if (result.skipped) {
-            noSkippedTests++;
-            if(!showFailedOnly)
-                grunt.log.ok('Skipping ' + result.title + ' ' + result.url + ' ' + ' value [' + result.value +
-                    ']');
-        } else if (result.isOk) {
-            noPassedTests++;
-            if (includePassed && !showFailedOnly) {
-                grunt.log.ok('The budget for ' + result.title + ' ' + result.url + ' passed [' + result.value +
-                    ']');
-            }
-        } else {
-            noFailingTests++;
-            failing = true;
-            grunt.log.error('[FAILED] The budget for ' + result.title + ' ' + result.url + ' failed. ' + result.description);
-        }
-    });
+  data.budget.forEach(function(result) {
+    if (result.skipped) {
+      noSkippedTests++;
+      if (!showFailedOnly)
+        grunt.log.ok('Skipping ' + result.title + ' ' + result.url + ' ' + ' value [' + result.value +
+          ']');
+    } else if (result.isOk) {
+      noPassedTests++;
+      if (includePassed && !showFailedOnly) {
+        grunt.log.ok('The budget for ' + result.title + ' ' + result.url + ' passed [' + result.value +
+          ']');
+      }
+    } else {
+      noFailingTests++;
+      failing = true;
+      grunt.log.error('[FAILED] The budget for ' + result.title + ' ' + result.url + ' failed. ' + result.description);
+    }
+  });
 
-    grunt.log.ok('We got ' + noPassedTests + ' passing tests, ' + noFailingTests + ' failing' + ((
-        noSkippedTests > 0) ? ' ' + noSkippedTests + ' skipped tests' : '.'));
+  grunt.log.ok('We got ' + noPassedTests + ' passing tests, ' + noFailingTests + ' failing' + ((
+    noSkippedTests > 0) ? ' ' + noSkippedTests + ' skipped tests' : '.'));
 
-    grunt.log.ok('------------------------------------------------- Finished checking budget');
+  grunt.log.ok('------------------------------------------------- Finished checking budget');
 
-    return failing;
+  return failing;
 }

--- a/tasks/sitespeedio.js
+++ b/tasks/sitespeedio.js
@@ -9,7 +9,8 @@
 
 var fs = require('fs'),
 	path = require('path'),
-	EOL = require('os').EOL;
+	EOL = require('os').EOL,
+	performance_analyzer = require('./lib/performance_analyzer');
 
 module.exports = function(grunt) {
 
@@ -40,7 +41,7 @@ module.exports = function(grunt) {
 			if (err) {
 				done(false);
 			} else if (data && data.budget) {
-				var isFailing = checkBudget(data, grunt);
+				var isFailing = performance_analyzer.checkBudget(data, grunt);
 				if (isFailing) {
 					done(false);
 				} else {
@@ -70,43 +71,3 @@ function readFile(options) {
 	options.file = undefined;
 }
 
-function checkBudget(data, grunt) {
-
-	// lets get the budget!
-	grunt.log.ok('------------------------------------------------- Check budget');
-	var failing = false;
-	var includePassed = grunt.config.get('includePassed');
-
-	var noPassedTests = 0;
-	var noFailingTests = 0;
-	var noSkippedTests = 0;
-
-	grunt.log.ok((includePassed ? 'Will include passing tests.' : 'Will not include passing tests.') +
-		' Change this by set grunt config to includePassed to true/false');
-
-	data.budget.forEach(function(result) {
-
-		if (result.skipped) {
-			noSkippedTests++;
-			grunt.log.ok('Skipping ' + result.title + ' ' + result.url + ' ' + ' value [' + result.value +
-				']');
-		} else if (result.isOk) {
-			noPassedTests++;
-			if (includePassed) {
-				grunt.log.ok('The budget for ' + result.title + ' ' + result.url + ' passed [' + result.value +
-					']');
-			}
-		} else {
-			noFailingTests++;
-			failing = true;
-			grunt.log.error('The budget for ' + result.title + ' ' + result.url + ' failed. ' + result.description);
-		}
-	});
-
-	grunt.log.ok('We got ' + noPassedTests + ' passing tests, ' + noFailingTests + ' failing' + ((
-		noSkippedTests > 0) ? ' ' + noSkippedTests + ' skipped tests' : '.'));
-
-	grunt.log.ok('------------------------------------------------- Finished checking budget');
-
-	return failing;
-}

--- a/test/test_budget_checking_output.js
+++ b/test/test_budget_checking_output.js
@@ -1,0 +1,91 @@
+var path = require('path'),
+    grunt = require('grunt'),
+    performance_analyzer = require('../tasks/lib/performance_analyzer'),
+    hooker = require('hooker');
+
+
+//Helper for testing stdout (from jshint: https://github.com/gruntjs/grunt-contrib-jshint/blob/master/test/jshint_test.js)
+var stdoutEqual = function(callback, done) {
+    var actual = '';
+    // Hook process.stdout.write
+    hooker.hook(grunt.log, ['error', 'ok'], {
+        // This gets executed before the original process.stdout.write.
+        pre: function(result) {
+            // Concatenate uncolored result onto actual.
+            temp = result;
+            actual += grunt.log.uncolor(result);
+            // Prevent the original process.stdout.write from executing.
+            return hooker.preempt();
+        }
+    });
+    // Execute the logging code to be tested.
+    callback();
+    // Restore process.stdout.write to its original value.
+    hooker.unhook(grunt.log, ['error', 'ok']);
+    // Actually test the actually-logged stdout string to the expected value.
+    done(actual);
+};
+
+function getSitespeedioResultData() {
+    return {
+        budget: [{
+            skipped: false,
+            title: 'foo',
+            url: 'bar',
+            value: 90,
+            isOk: true
+        }, {
+            skipped: true,
+            title: 'foo2',
+            url: 'bar2',
+            value: 90,
+            isOk: false
+        }, {
+            skipped: false,
+            title: 'foo2',
+            url: 'bar2',
+            value: 90,
+            isOk: false
+        }]
+    }
+}
+
+exports.tests = {
+    test_failed_result: function(test) {
+        test.expect(1);
+        stdoutEqual(function() {
+            performance_analyzer.checkBudget(getSitespeedioResultData(), grunt)
+        }, function(result) {
+            test.equal(result.indexOf('[FAILED]') !== -1, true, "Should print [FAILED] inside message when a result is not ok");
+            test.done();
+        });
+
+    },
+    test_showFailedOnly_switch: function(test) {
+        test.expect(1);
+
+        grunt.config.set("showFailedOnly", true);
+        grunt.config.set("includePassed", true);
+
+        stdoutEqual(function() {
+            performance_analyzer.checkBudget(getSitespeedioResultData(), grunt)
+        }, function(result) {
+            test.equal(result.indexOf('Skipped') == -1 && result.indexOf('passed') == -1, true, "Should not print any skipped or passed tests when showFailedOnly switch is set");
+            test.done();
+        });
+
+    },
+    test_includePassed_switch: function(test) {
+        test.expect(1);
+        grunt.config.set("showFailedOnly", false);
+        grunt.config.set("includePassed", true);
+
+        stdoutEqual(function() {
+            performance_analyzer.checkBudget(getSitespeedioResultData(), grunt)
+        }, function(result) {
+            test.equal(result.indexOf('Skipping') !== -1 && result.indexOf('passed') !== -1, true, "Should print skipped and passed tests when only includePassed switch is set");
+            test.done();
+        });
+
+    }
+};

--- a/test/test_budget_checking_output.js
+++ b/test/test_budget_checking_output.js
@@ -1,91 +1,92 @@
+'use strict';
+
 var path = require('path'),
-    grunt = require('grunt'),
-    performance_analyzer = require('../tasks/lib/performance_analyzer'),
-    hooker = require('hooker');
+  grunt = require('grunt'),
+  performance_analyzer = require('../tasks/lib/performance_analyzer'),
+  hooker = require('hooker');
 
 
 //Helper for testing stdout (from jshint: https://github.com/gruntjs/grunt-contrib-jshint/blob/master/test/jshint_test.js)
 var stdoutEqual = function(callback, done) {
-    var actual = '';
-    // Hook process.stdout.write
-    hooker.hook(grunt.log, ['error', 'ok'], {
-        // This gets executed before the original process.stdout.write.
-        pre: function(result) {
-            // Concatenate uncolored result onto actual.
-            temp = result;
-            actual += grunt.log.uncolor(result);
-            // Prevent the original process.stdout.write from executing.
-            return hooker.preempt();
-        }
-    });
-    // Execute the logging code to be tested.
-    callback();
-    // Restore process.stdout.write to its original value.
-    hooker.unhook(grunt.log, ['error', 'ok']);
-    // Actually test the actually-logged stdout string to the expected value.
-    done(actual);
+  var actual = '';
+  // Hook process.stdout.write
+  hooker.hook(grunt.log, ['error', 'ok'], {
+    // This gets executed before the original process.stdout.write.
+    pre: function(result) {
+      // Concatenate uncolored result onto actual.
+      actual += grunt.log.uncolor(result);
+      // Prevent the original process.stdout.write from executing.
+      return hooker.preempt();
+    }
+  });
+  // Execute the logging code to be tested.
+  callback();
+  // Restore process.stdout.write to its original value.
+  hooker.unhook(grunt.log, ['error', 'ok']);
+  // Actually test the actually-logged stdout string to the expected value.
+  done(actual);
 };
 
 function getSitespeedioResultData() {
-    return {
-        budget: [{
-            skipped: false,
-            title: 'foo',
-            url: 'bar',
-            value: 90,
-            isOk: true
-        }, {
-            skipped: true,
-            title: 'foo2',
-            url: 'bar2',
-            value: 90,
-            isOk: false
-        }, {
-            skipped: false,
-            title: 'foo2',
-            url: 'bar2',
-            value: 90,
-            isOk: false
-        }]
-    }
+  return {
+    budget: [{
+      skipped: false,
+      title: 'foo',
+      url: 'bar',
+      value: 90,
+      isOk: true
+    }, {
+      skipped: true,
+      title: 'foo2',
+      url: 'bar2',
+      value: 90,
+      isOk: false
+    }, {
+      skipped: false,
+      title: 'foo2',
+      url: 'bar2',
+      value: 90,
+      isOk: false
+    }]
+  }
 }
 
 exports.tests = {
-    test_failed_result: function(test) {
-        test.expect(1);
-        stdoutEqual(function() {
-            performance_analyzer.checkBudget(getSitespeedioResultData(), grunt)
-        }, function(result) {
-            test.equal(result.indexOf('[FAILED]') !== -1, true, "Should print [FAILED] inside message when a result is not ok");
-            test.done();
-        });
+  test_failed_result: function(test) {
+    test.expect(1);
+    stdoutEqual(function() {
+      performance_analyzer.checkBudget(getSitespeedioResultData(), grunt)
+    }, function(result) {
+      test.equal(result.indexOf('[FAILED]') !== -1, true, "Should print [FAILED] inside message when a result is not ok");
+      test.done();
+    });
 
-    },
-    test_showFailedOnly_switch: function(test) {
-        test.expect(1);
+  },
+  test_showFailedOnly_switch: function(test) {
+    test.expect(1);
 
-        grunt.config.set("showFailedOnly", true);
-        grunt.config.set("includePassed", true);
+    grunt.config.set("showFailedOnly", true);
+    grunt.config.set("includePassed", true);
 
-        stdoutEqual(function() {
-            performance_analyzer.checkBudget(getSitespeedioResultData(), grunt)
-        }, function(result) {
-            test.equal(result.indexOf('Skipped') == -1 && result.indexOf('passed') == -1, true, "Should not print any skipped or passed tests when showFailedOnly switch is set");
-            test.done();
-        });
+    stdoutEqual(function() {
+      performance_analyzer.checkBudget(getSitespeedioResultData(), grunt)
+    }, function(result) {
+      test.equal(result.indexOf('Skipped') == -1 && result.indexOf('passed') == -1, true, "Should not print any skipped or passed tests when showFailedOnly switch is set");
+      test.done();
+    });
 
-    },
-    test_includePassed_switch: function(test) {
-        test.expect(1);
-        grunt.config.set("showFailedOnly", false);
-        grunt.config.set("includePassed", true);
+  },
+  test_includePassed_switch: function(test) {
+    test.expect(1);
+    grunt.config.set("showFailedOnly", false);
+    grunt.config.set("includePassed", true);
 
-        stdoutEqual(function() {
-            performance_analyzer.checkBudget(getSitespeedioResultData(), grunt)
-        }, function(result) {
-            test.equal(result.indexOf('Skipping') !== -1 && result.indexOf('passed') !== -1, true, "Should print skipped and passed tests when only includePassed switch is set");
-            test.done();
-        });
+    stdoutEqual(function() {
+      performance_analyzer.checkBudget(getSitespeedioResultData(), grunt)
+    }, function(result) {
+      test.equal(result.indexOf('Skipping') !== -1 && result.indexOf('passed') !== -1, true, "Should print skipped and passed tests when only includePassed switch is set");
+      test.done();
+    });
 
-    }
+  }
 };


### PR DESCRIPTION
For our project we wanted to improve the output of the budget checking because we think that developers should only see the failed test results. We run the grunt-sitespeedio on Jenkins, so the console output looks rather unformatted compared to the terminal output. For the purpose of improving the readability of the output, we implemented a _showFailedOnly_ switch, which is set using the Grunt configuration. Also, if the _showFailedOnly_ switch is set, the _includePassed_ switch is ignored.

We also provided some tests using nodeunit, that test the budget checking output with and without the _showFailedOnly_ switch. In order to make the Budget Checking testing more convenient, we extracted the Budget Checking step into a separate library called: _/lib/performance_analyzer.js_
To run the tests, just use the _test_acceptance_ task.

We are looking forward to continue sharing our ideas with you!
@bobaaaaa, @zenderol 
