### PR TITLE
Changed the "deepth" argument to be "deep" in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ grunt.loadNpmTasks('grunt-sitespeedio');
 
 To start testing pages, you must configure either a start URL for your crawl (yep sitespeed.io will crawl your site for a configurable depth) or an array of specific URL:s that you want to test.
 
-Crawl the site with deepth 1.
+Crawl the site with depth 1.
 ```javascript
 sitespeedio: {
   default: {
     options: {
       url: 'http://www.sitespeed.io',
-      deepth: 1
+      deep: 1
     }
   }
 }
@@ -65,7 +65,7 @@ sitespeedio: {
   default: {
     options: {
       url: 'http://www.sitespeed.io',
-      deepth: 1,
+      deep: 1,
       resultBaseDir: '/my/new/dir/'
     }
   }
@@ -246,14 +246,14 @@ sitespeedio: {
 #### Performance Budget Google Page Speed Insights
 You can match your [Google Page Speed Score](https://developers.google.com/speed/pagespeed/) if your site is accessibble from the internet.
 
-In this example, we will crawl the start url for a deep of 2 and test every URL against the Google Page Speed Score for mobile and will fail if it is lower than 90.
+In this example, we will crawl the start url for a depth of 2 and test every URL against the Google Page Speed Score for mobile and will fail if it is lower than 90.
 
 ```javascript
 sitespeedio: {
   default: {
     options: {
       url: "http://www.sitespeed.io",
-      deepth: 2,
+      deep: 2,
       noYslow: true,
       gpsiKey: 'YOUR_SECRET_GOOGLE_KEY',
       profile: 'mobile',
@@ -284,7 +284,7 @@ Default value: NONE
 
 An Array with URL:s that you want to test. If you supply an array the exact pages will be tested.
 
-#### options.deepth
+#### options.deep
 
 Type `Number`
 Default value: 1 


### PR DESCRIPTION
Changed "deepth" in parts of README.md where it makes more sense in English to read as "depth" and changed it to "deep" where it was listed as an argument, since that is what sitespeed.io is going to expect: https://github.com/sitespeedio/sitespeed.io/blob/52ec32a240405ac283d42382942e6b2c861d113a/lib/config.js#L198

I assume config.depth of 0 would return false in the sitespeed.io code (I may make a pull request in that project to fix it). So, since "depth" or "deep" work, I went with "deep" to discourage people from using "depth: 0". 
