### PR TITLE
README: outputFolder should be resultBaseDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sitespeedio: {
   default: {
     options: {
       urls: ['https://www.sitespeed.io'],
-      outputFolder: '/my/new/dir/'
+      resultBaseDir: '/my/new/dir/'
     }
   }
 }


### PR DESCRIPTION
I was confused that the explanation was different to the example...  It seems `resultBaseDir` is the correct property name.

If this is incorrect feel free to ignore this PR :)
